### PR TITLE
feat: add support for running as DaemonSet

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4.1.0
         with:
-          go-version: '1.21.1'
+          go-version: '1.22.0'
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/deploy/kubernetes/Chart.yaml
+++ b/deploy/kubernetes/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 name: astrolavos
 sources:
 - https://github.com/dntosas/astrolavos
-version: 0.3.0
+version: 0.4.0
 dependencies:
 - name: common
   repository: "https://charts.bitnami.com/bitnami"

--- a/deploy/kubernetes/templates/deployment.yaml
+++ b/deploy/kubernetes/templates/deployment.yaml
@@ -1,5 +1,9 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+{{- if .Values.deployAsDaemonSet }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
@@ -17,8 +21,12 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- if .Values.updateStrategy }}
+  {{- if and .Values.updateStrategy (not .Values.deployAsDaemonSet) }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.updateStrategy (.Values.deployAsDaemonSet) }}
+  updateStrategy:
+    {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -9,6 +9,12 @@ commonAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 
+## There are scenarios where operators will need to deploy Astrolavos
+## pods on every node to increase chances of getting more accurate
+## cluster-wide insights. Following option switches deployment type
+## to be DaemonSet and support this.
+deployAsDaemonSet: true
+
 ## @param revisionHistoryLimit The number of old history to retain to allow rollback
 ##
 revisionHistoryLimit: 3
@@ -64,7 +70,7 @@ config:
 image:
   registry: ghcr.io
   repository: dntosas/astrolavos
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: Always
   pullSecrets: {}
 


### PR DESCRIPTION
There are scenarios where operators will need to deploy Astrolavos pods on every node to increase chances of getting more accurate cluster-wide insights. Following option switches deployment type to be DaemonSet and support this.

## Description
<!--- Describe your changes in detail -->
