### PR TITLE
feat(helm): add Datadog dashboard CRD and improve dashboard configurability

### DIFF
--- a/deploy/kubernetes/Chart.yaml
+++ b/deploy/kubernetes/Chart.yaml
@@ -12,7 +12,8 @@ maintainers:
 name: astrolavos
 sources:
 - https://github.com/dntosas/astrolavos
-version: 0.15.0
+version: 0.16.0
+appVersion: 0.16.0
 dependencies:
 - name: common
   repository: "https://charts.bitnami.com/bitnami"

--- a/deploy/kubernetes/dashboard/datadog-widgets.json
+++ b/deploy/kubernetes/dashboard/datadog-widgets.json
@@ -1,0 +1,212 @@
+[
+  {
+    "definition": {
+      "title": "DNS",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_dns_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 0, "y": 0, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "Connection",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_conn_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 4, "y": 0, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "Got Connection",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_gotconn_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 8, "y": 0, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "TLS",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_tls_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 0, "y": 4, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "First Byte",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_firstbyte_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 4, "y": 4, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "Total",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "p99:astrolavos_total_latency_seconds{$tag,$endpoint} by {tag,domain}"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "dog_classic",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 8, "y": 4, "width": 4, "height": 4 }
+  },
+  {
+    "definition": {
+      "title": "Errors",
+      "show_legend": true,
+      "legend_layout": "horizontal",
+      "legend_columns": ["avg", "min", "max", "value"],
+      "type": "timeseries",
+      "requests": [
+        {
+          "formulas": [{ "formula": "query1" }],
+          "queries": [
+            {
+              "name": "query1",
+              "data_source": "metrics",
+              "query": "sum:astrolavos_errors_total{$tag,$endpoint} by {error}.as_rate()"
+            }
+          ],
+          "response_format": "timeseries",
+          "display_type": "line",
+          "style": {
+            "palette": "warm",
+            "line_type": "solid",
+            "line_width": "normal"
+          }
+        }
+      ],
+      "yaxis": { "include_zero": true, "scale": "linear" }
+    },
+    "layout": { "x": 0, "y": 8, "width": 4, "height": 4 }
+  }
+]

--- a/deploy/kubernetes/templates/dashboard-datadog.yaml
+++ b/deploy/kubernetes/templates/dashboard-datadog.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.datadogDashboard.enabled }}
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogDashboard
+metadata:
+  name: {{ printf "%s-network-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ .Values.datadogDashboard.namespace | default (include "common.names.namespace" .) | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.datadogDashboard.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.datadogDashboard.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.datadogDashboard.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  title: {{ include "common.tplvalues.render" ( dict "value" .Values.datadogDashboard.title "context" $ ) }}
+  layoutType: ordered
+  tags:
+    - "app:astrolavos"
+    {{- range .Values.datadogDashboard.extraTags }}
+    - {{ . | quote }}
+    {{- end }}
+  templateVariables:
+    - name: tag
+      prefix: tag
+      defaults:
+        - "*"
+    - name: endpoint
+      prefix: domain
+      defaults:
+        - "*"
+    {{- range .Values.datadogDashboard.extraTemplateVariables }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
+  widgets: |-
+{{- .Files.Get "dashboard/datadog-widgets.json" | nindent 4 }}
+{{- end }}

--- a/deploy/kubernetes/templates/dashboard-grafana.yaml
+++ b/deploy/kubernetes/templates/dashboard-grafana.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-grafana-dashboard" (include "common.names.fullname" .) }}
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Values.grafanaDashboard.namespace | default (include "common.names.namespace" .) | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{ .Values.grafanaDashboard.sidecarLabel }}: {{ .Values.grafanaDashboard.sidecarLabelValue | quote }}
     {{- if .Values.commonLabels }}

--- a/deploy/kubernetes/values.yaml
+++ b/deploy/kubernetes/values.yaml
@@ -246,11 +246,44 @@ lifecycleHooks:
       path: /prestop
       port: http
 
+## Datadog Dashboard
+## ref: https://docs.datadoghq.com/containers/datadog_operator/crd_dashboard/
+datadogDashboard:
+  # -- Deploy Datadog dashboard as a DatadogDashboard CRD (requires Datadog Operator v0.6+)
+  enabled: false
+  # -- Dashboard title (supports tpl rendering, e.g. "{{ include \"common.names.fullname\" . }} Network Metrics")
+  title: "Astrolavos Network Metrics"
+  # -- Extra tags to add to the dashboard (in addition to app:astrolavos)
+  # e.g. ["team:platform", "env:production"]
+  extraTags: []
+  # -- Additional template variables for the dashboard
+  # e.g.
+  # extraTemplateVariables:
+  #   - name: cluster
+  #     prefix: kube_cluster_name
+  #     defaults:
+  #       - "*"
+  extraTemplateVariables:
+    - name: cluster
+      prefix: kube_cluster_name
+      defaults:
+        - "*"
+    - name: region
+      prefix: region
+      defaults:
+        - "*"
+  # -- Additional annotations for the DatadogDashboard resource
+  annotations: {}
+  # -- Override the namespace for the DatadogDashboard resource (defaults to release namespace)
+  namespace: ""
+
 ## Grafana Dashboard
 ## ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
 grafanaDashboard:
   # -- Deploy Grafana dashboard as a ConfigMap for sidecar autodiscovery
   enabled: false
+  # -- Override the namespace for the Grafana dashboard ConfigMap (defaults to release namespace)
+  namespace: ""
   # -- Label used by Grafana sidecar to discover dashboard ConfigMaps
   sidecarLabel: grafana_dashboard
   # -- Value for the sidecar discovery label


### PR DESCRIPTION
- Add DatadogDashboard CRD template with widgets loaded from static JSON file,
  mirroring the existing Grafana dashboard pattern
- Support configurable title (via tpl), extra tags, extra template variables,
  and namespace override for both Datadog and Grafana dashboards
- Rename Grafana template to consistent dashboard-grafana.yaml naming
- Bump chart and app version to 0.16.0
